### PR TITLE
Update landing page footer with official logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,21 +180,6 @@
       text-transform: uppercase;
     }
 
-    .brand-emblem {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.75rem;
-      font-size: 0.85rem;
-      letter-spacing: 0.3em;
-      font-weight: 500;
-      text-transform: uppercase;
-    }
-
-    .brand-emblem svg {
-      width: 38px;
-      height: 38px;
-    }
-
     .primary-nav a {
       text-decoration: none;
       color: var(--ocean);
@@ -450,21 +435,6 @@
       margin-inline: auto;
     }
 
-    .brand-logo {
-      padding: 1.25rem 1.5rem;
-      border: 2px solid rgba(196, 164, 98, 0.45);
-      border-radius: 20px;
-      background: var(--ivory);
-      max-width: 320px;
-      margin-inline: auto;
-    }
-
-    .brand-logo img {
-      width: 100%;
-      height: auto;
-      border-radius: 0;
-    }
-
     .join-form {
       display: grid;
       gap: 1.25rem;
@@ -562,28 +532,44 @@
     }
 
     footer {
-      padding: 3rem 1.75rem;
+      padding: 3rem 1.75rem 2.5rem;
       background-color: var(--ivory);
       border-top: 1px solid rgba(15, 42, 61, 0.08);
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: 1rem;
+      gap: 0.85rem;
       text-align: center;
+      color: #1E3A5F;
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     }
 
-    footer nav {
-      display: flex;
-      gap: 1.5rem;
-      font-size: 0.85rem;
-      letter-spacing: 0.18em;
+    .footer-logo {
+      width: 120px;
+      height: auto;
+      margin-bottom: 0.75rem;
+    }
+
+    footer small {
+      font-size: 0.9rem;
+      letter-spacing: 0.12em;
       text-transform: uppercase;
+      font-family: 'Playfair Display', 'Times New Roman', serif;
+    }
+
+    .footer-links {
+      display: flex;
+      gap: 2.25rem;
+      font-size: 0.85rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: inherit;
     }
 
     footer button {
       background: none;
       border: none;
-      color: var(--ocean);
+      color: inherit;
       cursor: pointer;
       padding: 0;
       font: inherit;
@@ -732,6 +718,16 @@
         gap: 0.75rem;
       }
     }
+
+    @media (max-width: 600px) {
+      .footer-logo {
+        width: 80px;
+      }
+
+      .footer-links {
+        gap: 1.5rem;
+      }
+    }
   </style>
 </head>
 <body id="top">
@@ -816,9 +812,6 @@
             <figure class="owner-photo">
               <img src="images/owner.jpg" alt="Founder photo" loading="lazy">
             </figure>
-            <figure class="brand-logo">
-              <img src="images/logo.svg" alt="The Itzaë Experience logo" loading="lazy">
-            </figure>
           </div>
           <div class="join-form">
             <h2 id="join-title">Join the private launch</h2>
@@ -843,15 +836,9 @@
     </main>
 
     <footer>
-      <div class="brand-emblem" aria-hidden="true">
-        <svg viewBox="0 0 60 60" role="img" aria-hidden="true">
-          <circle cx="30" cy="30" r="26" fill="none" stroke="var(--gold)" stroke-width="2"/>
-          <path d="M30 12c8 4 12 10 12 18s-4 14-12 18c-8-4-12-10-12-18s4-14 12-18z" fill="none" stroke="var(--gold)" stroke-width="2" stroke-linecap="round"/>
-        </svg>
-        <span>Itzae</span>
-      </div>
-      <small>© The Itzae Experience. Costa Rica</small>
-      <nav aria-label="Footer">
+      <img class="footer-logo" src="images/itzae-logo.png" alt="The Itzaë Experience official logo" loading="lazy">
+      <small>© The Itzaë Experience. Costa Rica.</small>
+      <nav class="footer-links" aria-label="Footer">
         <button type="button" data-modal-open="privacy">Privacy</button>
         <button type="button" data-modal-open="contact">Contact</button>
       </nav>


### PR DESCRIPTION
## Summary
- remove the duplicate placeholder logo card above the launch signup section
- restyle the footer to feature the official logo with responsive sizing and spacing
- refine footer typography and layout for the privacy and contact links

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68df22fb584c8325871ffbd4d9b54f4b