### PR TITLE
Refine header, hero background, and footer copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,10 +95,10 @@
       max-width: min(1100px, 92vw);
       margin: 0 auto;
       display: grid;
-      grid-template-columns: 1fr auto;
+      grid-template-columns: 1fr auto 1fr;
       align-items: center;
-      gap: 1rem;
-      padding: 1rem 0;
+      height: 60px;
+      padding: 0 1.5rem;
       position: relative;
     }
 
@@ -110,7 +110,7 @@
       color: #1E3A5F;
       text-decoration: none;
       white-space: nowrap;
-      grid-column: 1 / -1;
+      grid-column: 2;
       justify-self: center;
     }
 
@@ -120,18 +120,17 @@
       justify-content: center;
       width: 44px;
       height: 44px;
-      border-radius: 999px;
-      border: 1px solid rgba(30, 58, 95, 0.22);
+      border: none;
       background: none;
-      color: var(--ocean);
+      color: #1E3A5F;
       cursor: pointer;
-      transition: border-color 160ms ease, color 160ms ease;
-      grid-column: 2;
+      transition: color 160ms ease;
+      grid-column: 3;
       justify-self: end;
+      padding: 0;
     }
 
     .menu-toggle:hover {
-      border-color: var(--gold);
       color: var(--gold);
     }
 
@@ -142,8 +141,9 @@
 
     .menu-icon {
       position: relative;
-      width: 18px;
+      width: 24px;
       height: 2px;
+      border-radius: 999px;
       background: currentColor;
     }
 
@@ -152,18 +152,19 @@
       content: '';
       position: absolute;
       left: 0;
-      width: 18px;
+      width: 24px;
       height: 2px;
+      border-radius: 999px;
       background: currentColor;
       transition: transform 180ms ease, top 180ms ease, opacity 180ms ease;
     }
 
     .menu-icon::before {
-      top: -6px;
+      top: -7px;
     }
 
     .menu-icon::after {
-      top: 6px;
+      top: 7px;
     }
 
     .menu-toggle[aria-expanded="true"] .menu-icon {
@@ -187,7 +188,7 @@
       font-size: 0.85rem;
       letter-spacing: 0.18em;
       text-transform: uppercase;
-      grid-column: 2;
+      grid-column: 3;
       justify-self: end;
     }
 
@@ -598,9 +599,10 @@
 
     footer small {
       font-size: 0.9rem;
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
-      font-family: 'Playfair Display', 'Times New Roman', serif;
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      color: #1E3A5F;
+      letter-spacing: normal;
+      text-transform: none;
     }
 
     .footer-links {
@@ -906,7 +908,7 @@
 
     <footer>
       <img class="footer-logo" src="logo.png" alt="The Itzaë Experience official logo" loading="lazy">
-      <small>© The Itzaë Experience. Costa Rica.</small>
+      <small>© The Itzaë Experience — All rights reserved 2025</small>
       <nav class="footer-links" aria-label="Footer">
         <button type="button" data-modal-open="privacy">Privacy</button>
         <button type="button" data-modal-open="contact">Contact</button>


### PR DESCRIPTION
## Summary
- restyle the sticky header to a 60px layout with centered branding and a simplified navy hamburger icon
- ensure the hero keeps the yacht background with centered content inside a translucent panel and CTA scrolling to the join section
- refresh the footer copy while retaining the logo image plus privacy and contact links

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68df2f20b6f48325a14952160e05a435