### PR TITLE
Update navigation labels for experiences and contact

### DIFF
--- a/index.html
+++ b/index.html
@@ -799,10 +799,9 @@
           <span class="menu-icon" aria-hidden="true"></span>
         </button>
         <nav id="primary-navigation" class="primary-nav" aria-label="Main navigation">
-          <a href="#about">About</a>
-          <a href="#roots">Roots</a>
-          <a href="#gallery">Gallery</a>
-          <a href="#join">Join</a>
+          <a href="#experiences">Experiences</a>
+          <a href="#roots">Our Roots</a>
+          <a href="#contact">Contact</a>
         </nav>
       </div>
     </header>
@@ -820,15 +819,15 @@
           <h1 id="hero-title">A new way to experience Costa Rica</h1>
           <p class="subheadline">Curated adventures at sea and in the wild. Designed with heart. Guided by tradition.</p>
           <div class="cta">
-            <a class="primary-button" href="#join">Join the List</a>
+            <a class="primary-button" href="#contact">Join the List</a>
             <small>Private launch invitations only</small>
           </div>
           <p class="countdown" data-countdown>Launching soon — December 15</p>
         </div>
       </section>
 
-      <section class="section" id="about" aria-labelledby="about-title">
-        <h2 id="about-title">Curated. Private. Unforgettable.</h2>
+      <section class="section" id="experiences" aria-labelledby="experiences-title">
+        <h2 id="experiences-title">Curated. Private. Unforgettable.</h2>
         <p>From island picnics with chef-cooked BBQ to golden hour cruises and jungle trails, every itinerary is crafted to feel rare and personal.</p>
         <ul>
           <li>Ocean day to deserted island with chef BBQ</li>
@@ -863,7 +862,7 @@
         </div>
       </section>
 
-      <section class="section join-section" id="join" aria-labelledby="join-title">
+      <section class="section join-section" id="contact" aria-labelledby="join-title">
         <div class="join-container">
           <h2 id="join-title">Join the private launch</h2>
           <p>Enter your email to receive the first invitations, bespoke itineraries, and stories from The Itzaë Experience.</p>


### PR DESCRIPTION
## Summary
- update the sticky header navigation links to feature Experiences, Our Roots, and Contact anchors
- retarget the hero call-to-action button to the new contact section
- rename the About and Join sections to Experiences and Contact respectively to keep anchor alignment

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68df383c24e483258ac2a8a5c33aa277