### PR TITLE
Use Cormorant Garamond for body copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400;500&display=swap" rel="stylesheet">
   <style>
     :root {
@@ -52,7 +53,7 @@
     }
 
     body, p, li, span, .section-text {
-      font-family: 'IBM Plex Mono', monospace;
+      font-family: 'Cormorant Garamond', serif;
       font-weight: 400;
       line-height: 1.7;
       color: #0F2A3D;


### PR DESCRIPTION
## Summary
- import the Cormorant Garamond family from Google Fonts
- apply Cormorant Garamond styling to body copy elements while preserving heading typography

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df3cdc339c832585fa60ec79644964